### PR TITLE
Issue + PR template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,6 @@
 ---
 name: Bug
-about: Create a bug report to help us improve
+about: Create a bug report to help this product
 title: ''
 labels: kind/bug
 assignees: ''
@@ -8,35 +8,43 @@ assignees: ''
 ---
 
 ## Summary
-A clear and concise description of what the bug is.
+
+*Provide brief overview and context for the discovered bug.*
 
 ## Steps to Reproduce
-Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 ## Expected Results
-A clear and concise description of what you expected to happen.
 
-## Actual Results (including error logs, if applicable)
-A clear and concise description of what actually did happen.
+*A clear and concise description of what you expected to happen.*
+
+## Actual Results
+
+*A clear and concise description of what actually did happen. Include logs and
+screens shots, whenever possible*
 
 ## Reproducible
+
    * [ ] Always 
    * [ ] Sometimes
    * [ ] Non-Reproducible
    
 ## Version/Tag number
-What version of the product are you running? Any version info that you can share is helpful. 
-For example, you might give the version from Docker logs, the Docker tag, a specific download URL, 
-the output of the `/info` route, etc.
+
+*What version of the product are you running? Any version info that you can
+share is helpful.  For example, you might give the version from Docker logs,
+the Docker tag, a specific download URL, the output of the `/info` route, etc.*
 
 ## Environment setup
-Can you describe the environment in which this product is running? Is it running on a VM / in a container / in a cloud? 
-Which cloud provider? Which container orchestrator (including version)? 
-The more info you can share about your runtime environment, the better we may be able to reproduce the issue.
+
+* Can you describe the environment in which this product is running? Is it running on a VM / in a container / in a cloud? 
+* Which cloud provider? Which container orchestrator (including version)? 
+* The more info you can share about your runtime environment, the better we may be able to reproduce the issue.
 
 ## Additional Information
-Add any other context about the problem here.
+
+*Add any other context about the problem here.*

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,29 @@
+---
+name: Epic
+about: Create an epic to plan a major new initiative
+title: ''
+labels: Epic, kind/epic
+assignees: ''
+
+---
+
+# _Name of the Epic_
+
+_Provide a short description of the epic here._
+
+## References
+- [_Aha Card Title_](https://cyberark.aha.io/features/)
+- [Feature Doc]()
+
+## Team
+- **Product Manager**: _Persons Name_ (@username)
+- **Product Owner**: _Persons Name_ (@username)
+- **Engineering Manager**: _Persons Name_ (@username)
+- **Feature Lead**: _Persons Name_ (@username)
+- **Engineers**:
+    - _Persons Name_ (@username)
+- **Technical Writer**: _Persons Name_ (@username)
+
+## Stories
+
+_List the stories here._

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,37 @@
+---
+name: User Story
+about: Propose an enhancement via a user story
+title: ''
+labels: kind/user-story
+assignees: ''
+
+---
+## User Story
+
+*Using the form below, relate the desired product behavior.  Feel free to
+additional, clarifying details below it if needed.  For more details on user
+stories, see this [article](https://www.atlassian.com/agile/project-management/user-stories).*
+
+**As a** <persona name>
+**I want** <desired behavior>
+**So that** <value of behavior> 
+
+### Test Scenarios
+
+*If desired, add one or more test scenarios required for user story acceptance.
+Ideally, they are executed by automated tests. For more details on Gerkin syntax,
+see this [article](https://cucumber.io/docs/gherkin/reference/)*
+
+**Given** <this setup/context>
+**When** <an action/event occurs>
+**Then** <the expected behavior/outcome>
+
+## Implementation
+
+### Notes
+
+### Implementation Tasks
+
+*The following issues have been created to implement this user story:*
+
+* <issue link>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,54 @@
-### What does this PR do?
+### Desired Outcome
+
+*Please describe the desired outcome for this PR.  Said another way, what was
+the original request that resulted in these code changes?  Feel free to copy
+this information from the connected issue.*
+
+### Implemented Changes
+
+*Describe how the desired outcome above has been achieved with this PR. In
+particular, consider:*
+
 - _What's changed? Why were these changes made?_
 - _How should the reviewer approach this PR, especially if manual tests are required?_
 - _Are there relevant screenshots you can add to the PR description?_
 
-### What ticket does this PR close?
-Resolves #[relevant GitHub issues, eg 76]
+### Connected Issue/Story
 
-### Checklists
+Resolves #[relevant GitHub issue(s), e.g. 76]
 
-#### Change log
+CyberArk internal issue link: [insert issue ID]()
+
+### Definition of Done
+*At least 1 todo must be completed in the sections below for the PR to be
+merged.*
+
+#### Changelog
+
 - [ ] The CHANGELOG has been updated, or
-- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update
+- [ ] This PR does not include user-facing changes and doesn't require a
+  CHANGELOG update
 
 #### Test coverage
-- [ ] This PR includes new unit and integration tests to go with the code changes, or
+
+- [ ] This PR includes new unit and integration tests to go with the code
+  changes, or
 - [ ] The changes in this PR do not require tests
 
 #### Documentation
-- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
+
+- [ ] Docs (e.g. `README`s) were updated in this PR
+- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
 - [ ] This PR does not require updating any documentation
+
+#### Behavior
+
+- [ ] This PR changes product behavior and has been reviewed by a PO, or
+- [ ] These changes are part of a larger initiative that will be reviewed later, or
+- [ ] No behavior was changed with this PR
+
+#### Security
+
+- [ ] Security architect has reviewed the changes in this PR,
+- [ ] These changes are part of a larger initiative with a separate security review, or
+- [ ] There are no security aspects to these changes 


### PR DESCRIPTION
### What does this PR do?

* Added epic, task and user-story issue templates.
* Minor changes/improvements to bug and PR templates.
* Added config file to require use of an issue template.

Ideally, if @izgeri and @sjacobs146 agree, we can started deleting issue templates from individual repos so that these canonical ones will be used.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

**Should this repo have a CHANGELOG?**

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
